### PR TITLE
Allow pandas to have duplicated column names for 2d tensors in neural net

### DIFF
--- a/mlflow/pyfunc/scoring_server.py
+++ b/mlflow/pyfunc/scoring_server.py
@@ -53,11 +53,13 @@ def init(model):
         if flask.request.content_type == 'text/csv':
             data = flask.request.data.decode('utf-8')
             s = StringIO(data)
-            data = pd.read_csv(s)
+            data = pd.read_csv(s, header=None)
+            # HACK https://github.com/pandas-dev/pandas/issues/19383
+            data = data.rename(columns=data.iloc[0], copy=False).iloc[1:].reset_index(drop=True)
         elif flask.request.content_type == 'application/json':
             data = flask.request.data.decode('utf-8')
             s = StringIO(data)
-            data = pd.read_json(s, orient="records")
+            data = pd.read_json(s, orient="split")
         else:
             return flask.Response(
                 response='This predictor only supports CSV or JSON  data, got %s' % str(

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -86,6 +86,8 @@ class NumpyEncoder(JSONEncoder):
     def default(self, o):  # pylint: disable=E0202
         if isinstance(o, numpy.generic):
             return numpy.asscalar(o)
+        if isinstance(o, numpy.ndarray):
+            return o.tolist()
         return JSONEncoder.default(self, o)
 
 

--- a/tests/tensorflow/conftest.py
+++ b/tests/tensorflow/conftest.py
@@ -1,0 +1,62 @@
+import os
+
+import pytest
+import tensorflow as tf
+from tensorflow import keras
+from tensorflow.python.saved_model import builder as saved_model_builder
+from tensorflow.python.saved_model import tag_constants, signature_constants
+
+
+@pytest.fixture
+def boston_housing_model(tmpdir):
+    tf.reset_default_graph()
+    saved_model_path = os.path.join(str(tmpdir), "saved_model")
+
+    # model training
+    boston_housing = keras.datasets.boston_housing
+    (train_data, train_labels), (test_data, test_labels) = boston_housing.load_data()
+
+    model = keras.Sequential([
+        keras.layers.Dense(64, activation=tf.nn.relu,
+                           input_shape=(train_data.shape[1],)),
+        keras.layers.Dense(64, activation=tf.nn.relu),
+        keras.layers.Dense(1)
+    ])
+    optimizer = tf.train.RMSPropOptimizer(0.001)
+    model.compile(loss='mse', optimizer=optimizer, metrics=['mae'])
+    model.fit(train_data, train_labels, epochs=100, verbose=0)
+
+    # model saving
+    input_tensor_name = 'input'
+    output_tensor_name = 'output'
+    prediction_signature = tf.saved_model.signature_def_utils.predict_signature_def(
+        {input_tensor_name: model.input}, {output_tensor_name: model.output})
+
+    builder = saved_model_builder.SavedModelBuilder(saved_model_path)
+    legacy_init_op = tf.group(tf.tables_initializer(), name='legacy_init_op')
+
+    # Initialize global variables and the model
+    init_op = tf.group(tf.global_variables_initializer(), tf.local_variables_initializer())
+    with tf.Session() as sess:
+        sess.run(init_op)
+
+        # Add the meta_graph and the variables to the builder
+        builder.add_meta_graph_and_variables(
+            sess, [tag_constants.SERVING],
+            signature_def_map={
+                signature_constants.DEFAULT_SERVING_SIGNATURE_DEF_KEY:
+                    prediction_signature,
+            },
+            legacy_init_op=legacy_init_op)
+
+        # save the graph
+        builder.save()
+
+    return {
+        'path': saved_model_path,
+        'meta_graph_tags': [tf.saved_model.tag_constants.SERVING],
+        'signature_def_key': signature_constants.DEFAULT_SERVING_SIGNATURE_DEF_KEY,
+        'test_data': test_data,
+        'input_tensor_name': input_tensor_name,
+        'output_tensor_name': output_tensor_name,
+    }

--- a/tests/tensorflow/test_keras_model_as_tensorflow_graph.py
+++ b/tests/tensorflow/test_keras_model_as_tensorflow_graph.py
@@ -1,0 +1,68 @@
+"""
+AWS Sagemaker converts keras models to tensorflow graph on saving.
+In order to process 2D input tensors in such models, pandas duplicated column
+names should be allowed.
+"""
+
+import os
+
+import mlflow.tensorflow
+from mlflow import pyfunc
+import pandas as pd
+
+
+def test_keras_boston_housing_scoring_server_csv_prediction(tmpdir, boston_housing_model):
+    model_path = os.path.join(str(tmpdir), "model")
+    mlflow.tensorflow.save_model(tf_saved_model_dir=boston_housing_model["path"],
+                                 tf_meta_graph_tags=boston_housing_model["meta_graph_tags"],
+                                 tf_signature_def_key=boston_housing_model["signature_def_key"],
+                                 path=model_path)
+    pyfunc_wrapper = pyfunc.load_pyfunc(model_path)
+
+    df = pd.DataFrame(
+        boston_housing_model["test_data"],
+        columns=[boston_housing_model["input_tensor_name"]] *
+        boston_housing_model["test_data"].shape[1])
+
+    test_data_path = os.path.join(str(tmpdir), "test_data.csv")
+    df.to_csv(test_data_path, index=False)
+
+    fp = open(test_data_path)
+    data = pd.read_csv(fp, header=None)  # HACK https://github.com/pandas-dev/pandas/issues/19383
+    data = data.rename(columns=data.iloc[0], copy=False).iloc[1:].reset_index(drop=True)
+
+    predicts = pyfunc_wrapper.predict(data)
+
+    assert predicts.shape[0] == boston_housing_model["test_data"].shape[0]
+    assert predicts.shape[1] == 1
+
+    predicts_list = predicts[boston_housing_model["output_tensor_name"]].tolist()
+    assert len(list(filter(None, predicts_list))) == predicts.shape[0]
+
+
+def test_keras_boston_housing_scoring_server_json_prediction(tmpdir, boston_housing_model):
+    model_path = os.path.join(str(tmpdir), "model")
+    mlflow.tensorflow.save_model(tf_saved_model_dir=boston_housing_model["path"],
+                                 tf_meta_graph_tags=boston_housing_model["meta_graph_tags"],
+                                 tf_signature_def_key=boston_housing_model["signature_def_key"],
+                                 path=model_path)
+    pyfunc_wrapper = pyfunc.load_pyfunc(model_path)
+
+    df = pd.DataFrame(
+        boston_housing_model["test_data"],
+        columns=[boston_housing_model["input_tensor_name"]] *
+        boston_housing_model["test_data"].shape[1])
+
+    test_data_path = os.path.join(str(tmpdir), "test_data.json")
+    df.to_json(test_data_path, orient="split")
+
+    fp = open(test_data_path)
+    data = pd.read_json(fp, orient="split")
+
+    predicts = pyfunc_wrapper.predict(data)
+
+    assert predicts.shape[0] == boston_housing_model["test_data"].shape[0]
+    assert predicts.shape[1] == 1
+
+    predicts_list = predicts[boston_housing_model["output_tensor_name"]].tolist()
+    assert len(list(filter(None, predicts_list))) == predicts.shape[0]


### PR DESCRIPTION
AWS Sagemaker converts keras models to tensorflow graph on saving.
In order to process 2D input tensors in such models, pandas duplicated column
names should be allowed.